### PR TITLE
chore: set .nvmrc (lts/gallium)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v16.20.2
+lts/gallium


### PR DESCRIPTION
Zmienia `.nvmrc` na codename `lts/gallium`.

konwersja z 'v16.20.2' -> codename.

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.